### PR TITLE
Async support for NCalc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+﻿[*.cs]
+
+# CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+dotnet_diagnostic.CS4014.severity = error
+
+# LindhartAnalyserMissingAwaitWarning: The method 'NCalc.Domain.LogicalExpression.AcceptAsync(NCalc.Domain.IAsyncLogicalExpressionVisitor)' returns a Task that was not awaited
+dotnet_diagnostic.LindhartAnalyserMissingAwaitWarning.severity = error

--- a/NCalc.sln
+++ b/NCalc.sln
@@ -1,15 +1,19 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29519.181
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0F00354F-7E5B-4E3C-9734-E4C1589C9220}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCalc", "src\NCalc\NCalc.csproj", "{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NCalc", "src\NCalc\NCalc.csproj", "{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{ABBE7E83-6ACF-47AB-B8C8-520F77D962F0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCalc", "test\NCalc\NCalc.Test.csproj", "{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NCalc.Test", "test\NCalc\NCalc.Test.csproj", "{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9F97B816-14B8-40B2-82B9-D53B29EB1F70}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,37 +24,40 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|x64.ActiveCfg = Debug|x64
-		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|x64.Build.0 = Debug|x64
-		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|x86.ActiveCfg = Debug|x86
-		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|x86.Build.0 = Debug|x86
+		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|x64.Build.0 = Debug|Any CPU
+		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Debug|x86.Build.0 = Debug|Any CPU
 		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|x64.ActiveCfg = Release|x64
-		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|x64.Build.0 = Release|x64
-		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|x86.ActiveCfg = Release|x86
-		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|x86.Build.0 = Release|x86
+		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|x64.ActiveCfg = Release|Any CPU
+		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|x64.Build.0 = Release|Any CPU
+		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|x86.ActiveCfg = Release|Any CPU
+		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2}.Release|x86.Build.0 = Release|Any CPU
 		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|x64.ActiveCfg = Debug|x64
-		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|x64.Build.0 = Debug|x64
-		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|x86.ActiveCfg = Debug|x86
-		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|x86.Build.0 = Debug|x86
+		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|x64.Build.0 = Debug|Any CPU
+		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Debug|x86.Build.0 = Debug|Any CPU
 		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|x64.ActiveCfg = Release|x64
-		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|x64.Build.0 = Release|x64
-		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|x86.ActiveCfg = Release|x86
-		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|x86.Build.0 = Release|x86
+		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|x64.ActiveCfg = Release|Any CPU
+		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|x64.Build.0 = Release|Any CPU
+		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|x86.ActiveCfg = Release|Any CPU
+		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8BDEE45A-C609-4B02-B4CB-3CA6AA4CDFF2} = {0F00354F-7E5B-4E3C-9734-E4C1589C9220}
 		{90DD134B-B5BD-42ED-9ABE-A2BFE6DA859C} = {ABBE7E83-6ACF-47AB-B8C8-520F77D962F0}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {14051477-D753-4758-A16E-7771B079C008}
 	EndGlobalSection
 EndGlobal

--- a/src/NCalc/Domain/BinaryExpression.cs
+++ b/src/NCalc/Domain/BinaryExpression.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace NCalc.Domain
 {
     public class BinaryExpression : LogicalExpression
@@ -18,6 +20,11 @@ namespace NCalc.Domain
         public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
+        }
+
+        public override async Task AcceptAsync(IAsyncLogicalExpressionVisitor visitor)
+        {
+            await visitor.VisitAsync(this);
         }
     }
 

--- a/src/NCalc/Domain/Function.cs
+++ b/src/NCalc/Domain/Function.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace NCalc.Domain
 {
     public class Function : LogicalExpression
@@ -15,6 +17,11 @@ namespace NCalc.Domain
         public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
+        }
+
+        public override async Task AcceptAsync(IAsyncLogicalExpressionVisitor visitor)
+        {
+            await visitor.VisitAsync(this);
         }
     }
 }

--- a/src/NCalc/Domain/IAsyncLogicalExpressionVisitor.cs
+++ b/src/NCalc/Domain/IAsyncLogicalExpressionVisitor.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace NCalc.Domain
+{
+    public interface IAsyncLogicalExpressionVisitor
+    {
+        Task VisitAsync(LogicalExpression expression);
+        Task VisitAsync(TernaryExpression expression);
+        Task VisitAsync(BinaryExpression expression);
+        Task VisitAsync(UnaryExpression expression);
+        Task VisitAsync(ValueExpression expression);
+        Task VisitAsync(Function function);
+        Task VisitAsync(Identifier function);
+    }
+}

--- a/src/NCalc/Domain/Identifier.cs
+++ b/src/NCalc/Domain/Identifier.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace NCalc.Domain
 {
     public class Identifier : LogicalExpression
@@ -12,6 +14,11 @@ namespace NCalc.Domain
         public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
+        }
+
+        public override async Task AcceptAsync(IAsyncLogicalExpressionVisitor visitor)
+        {
+            await visitor.VisitAsync(this);
         }
     }
 }

--- a/src/NCalc/Domain/LogicalExpression.cs
+++ b/src/NCalc/Domain/LogicalExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace NCalc.Domain
 {
@@ -233,6 +234,11 @@ namespace NCalc.Domain
         public virtual void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
+        }
+
+        public virtual async Task AcceptAsync(IAsyncLogicalExpressionVisitor visitor)
+        {
+            await visitor.VisitAsync(this);
         }
     }
 }

--- a/src/NCalc/Domain/TernaryExpression.cs
+++ b/src/NCalc/Domain/TernaryExpression.cs
@@ -1,4 +1,6 @@
-﻿namespace NCalc.Domain
+﻿using System.Threading.Tasks;
+
+namespace NCalc.Domain
 {
     public class TernaryExpression : LogicalExpression
     {
@@ -18,6 +20,11 @@
         public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
+        }
+
+        public override async Task AcceptAsync(IAsyncLogicalExpressionVisitor visitor)
+        {
+            await visitor.VisitAsync(this);
         }
     }
 }

--- a/src/NCalc/Domain/UnaryExpression.cs
+++ b/src/NCalc/Domain/UnaryExpression.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace NCalc.Domain
 {
     public class UnaryExpression : LogicalExpression
@@ -15,6 +17,11 @@ namespace NCalc.Domain
         public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
+        }
+
+        public override async Task AcceptAsync(IAsyncLogicalExpressionVisitor visitor)
+        {
+            await visitor.VisitAsync(this);
         }
     }
 

--- a/src/NCalc/Domain/Value.cs
+++ b/src/NCalc/Domain/Value.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Reflection;
+using System.Threading.Tasks;
 
 namespace NCalc.Domain
 {
@@ -88,6 +88,11 @@ namespace NCalc.Domain
         public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
+        }
+
+        public override async Task AcceptAsync(IAsyncLogicalExpressionVisitor visitor)
+        {
+            await visitor.VisitAsync(this);
         }
     }
 

--- a/src/NCalc/NCalc.csproj
+++ b/src/NCalc/NCalc.csproj
@@ -25,6 +25,10 @@
     <UserSecretsId>Alterdata Software</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\..\.editorconfig" Link=".editorconfig" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Antlr3.Runtime" Version="3.5.1" />
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/test/NCalc/NCalc.Test.csproj
+++ b/test/NCalc/NCalc.Test.csproj
@@ -25,6 +25,7 @@
     <UserSecretsId>Alterdata Software</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />


### PR DESCRIPTION
This PR extends NCalc with an async interface for evaluating expressions. 

The `EvaluateAsync` interface has one difference to the `Evaluate`, in that event callbacks for parameters and functions are not supported. Instead async functions have to be provided either when constructing the `Expression` or when calling `EvaluateAsync`.

The old synchronous interface is still supported, but calls the async interface. This should not cause any behaviour changes to code that uses this interface, since it already is synchronous. However, since a task is still created and then waited upon in `Evaluate()`, this may mean that the evaluation task executes on a different thread to the calling task. This potential for a breaking change might merit this not being included in the standard NCalc, but rather forking the entire project into a new NCalc-Async.

Another breaking change is that the class `EvaluationVisitor` is now wholly async. This should be an internal class (even if public) that noone uses outside NCalc, but people might have extended it or done other changes to it. Those would no longer work with the async support.

Also, I'm not sure what your maintenance principle is for this project. If it is a fork of NCalc-Edge presumably it would follow that one, and not take new functionality like this. In that case this might be another reason to create a new project, unless the https://github.com/ncalc/ncalc should be interested in adding this instead. (The PR is against this project since we're using the nugets of NCalc-NetCore in our software.)
